### PR TITLE
API extension for Support for Retsynth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huandu/go-sqlbuilder v1.18.0 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,11 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-sqlbuilder v1.18.0 h1:J86ytJDvN8h+9ia3amvs4rT9Or0y9c5BDslQV7uPwlU=
+github.com/huandu/go-sqlbuilder v1.18.0/go.mod h1:nUVmMitjOmn/zacMLXT0d3Yd3RHoO2K+vy906JzqxMI=
+github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
+github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/pkg/retsynth/models.go
+++ b/pkg/retsynth/models.go
@@ -1,0 +1,94 @@
+package retsynth
+
+
+// Models is a struct that contains the information about a model
+type Model struct {
+	ID 		string `db:"ID"` //ID is the model ID
+	FileName 	string `db:"file_name"` //FileName is the name of the model file
+}
+
+//FBA Models is a struct that contains the information about a Flux Balanance Analysis model
+type FBAModel struct {
+	ID 		string `db:"ID"` //ID is the FBA model ID
+	FileName 	string `db:"file_name"`
+}
+
+// Compounds is a struct that contains the information about a compound
+type Compound struct {
+	ID 		string `db:"ID"` //ID is the compound ID
+	Name 		string `db:"name"` //Name is the compound name
+	Compartments 	string `db:"compartments"` //Compartments is the compartment of the compound
+	KeggID 		string `db:"kegg_id"` //KeggID is the Kegg ID of the compound
+	ChemicalFormula string `db:"chemicalformula"` //ChemicalFormula is the chemical formula of the compound
+	InchiString 	string `db:"inchistring"` //InchiString is the Inchi string of the compound
+	CASNumber 	string `db:"casnumber"` //CASNumber is the CAS number of the compound
+}
+
+// Compartments is a struct that contains the information about a compartment
+type Compartment struct {
+	ID 		string `db:"ID"` //ID is the compartment ID
+	Name 		string `db:"name"` //Name is the compartment name
+}
+
+// ModelCompounds is a struct that contains the information about a  compound model
+type ModelCompound struct {
+	CompundID 		string `db:"cpd_ID"` //CompundID is the compound ID
+	ModelID 	string `db:"model_ID"` //ModelID is the model ID
+}
+
+// Reactions is a struct that contains the information about a reaction
+type Reaction struct {
+	ID 		string `db:"ID"` //ID is the reaction ID
+	Name 		string `db:"name"` //Name is the reaction name
+	KeggID 		string `db:"kegg_id"` //KeggID is the Kegg ID of the reaction
+	Type 		string `db:"type"` //Type is the type of the reaction
+}
+
+
+// ModelReactions is a struct that contains the information about a reaction model
+type ModelReaction struct {
+	ReactionID 	string `db:"reaction_ID"` //ReactionID is the reaction ID
+	ModelID 	string `db:"model_ID"` //ModelID is the model ID
+	IsReversible 	bool `db:"is_rev"` //IsReversible is the reversibility of the reaction
+}
+
+// ReactionCompunds is a struct that contains the information about a reaction compound
+type ReactionCompound struct {
+	ReactionID 	string `db:"reaction_ID"` //ReactionID is the reaction ID
+	CompoundID 	string `db:"cpd_ID"` //CompoundID is the compound ID
+	IsProduct 	bool `db:"is_prod"` //IsProduct is the product of the reaction
+	Stochiometry 	int `db:"stochiometry"` //Stochiometry is the stochiometry of the reaction
+	FileNumer 	int `db:"filenum"` //FileNumer is the file number of the reaction
+}
+
+// ReactionReversibility is a struct that contains the information about a reaction reversibility
+type ReactionReversibility struct {
+	ReactionID 	string `db:"reaction_ID"` //ReactionID is the reaction ID
+	IsReversible 	bool `db:"is_reversible"` //IsReversible is the reversibility of the reaction
+}
+
+// ReactionGene is a struct that contains the information about the reaction gene
+type ReactionGene struct {
+	ReactionID 	string `db:"reaction_ID"` //ReactionID is the reaction ID
+	ModelID 	string `db:"model_ID"` //ModelID is the model ID
+	GeneID 		string `db:"gene_ID"` //GeneID is the gene ID
+}
+
+// ReactionProtien is a struct that contains the information about the reaction protien
+type ReactionProtien struct {
+	ReactionID 	string `db:"reaction_ID"` //ReactionID is the reaction ID
+	ModelID 	string `db:"model_ID"` //ModelID is the model ID
+	ProtienID 	string `db:"protien_ID"` //ProtienID is the protien ID
+}
+
+// Cluster is a struct that contains the information about a cluster
+type Cluster struct {
+	ClusterNum 	string `db:"cluster_num"`
+	ClusterID 	string `db:"ID"`
+}
+
+// OringalDBCompooundIDs is a struct that contains the information about the original database compound IDs
+type OringalDBCompooundIDs struct {
+	CompoundID 	string `db:"ID"` //CompoundID is the compound ID
+	InchiID 	string `db:"inchi_id"` //InchiID is the Inchi ID
+}

--- a/pkg/retsynth/queries.go
+++ b/pkg/retsynth/queries.go
@@ -1,0 +1,766 @@
+package retsynth
+
+import (
+	"os"
+	"strings"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+
+
+// Get the file path of the Retsynth database from the environment variable, if it exists otherwise set default path
+var RetsynthDBPath, ok = os.LookupEnv("RETSYNTH_DB_PATH")
+if !ok {
+	RetsynthDBPath = "./minimal.db"
+}
+
+
+//Easy database connector
+func ConnectDB() (*sqlx.DB, error) {
+	var db *sqlx.DB
+	var err error
+	db, err = sqlx.Connect("sqlite3", RetsynthDBPath)
+	if err != nil {
+		return db, err
+	}
+	return db, err
+}
+
+//Retrieves unique metabolic clusters (organisms with the exact same metabolism) in the database
+func GetUniqueMetabolicClusters() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var clusters []string
+	query := "SELECT DISTINCT cluster_num FROM cluster"
+	err = db.Select(&clusters, query)
+	if err != nil {
+		return nil, err
+	}
+	return clusters, err
+}
+
+
+//Retrieves model IDs from a specified cluster in the database
+func GetModelIDsFromCluster(cluster string) ([]cluster, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var models []string
+	query := "SELECT model_id FROM cluster WHERE cluster_num = ?"
+	err = db.Select(&models, query, cluster)
+	if err != nil {
+		return nil, err
+	}
+	return models, err
+}
+
+// Retrieves all model IDs from the database
+func GetAllModelIDs() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var models []string
+	query := "SELECT DISTINCT model_id FROM model"
+	err = db.Select(&models, query)
+	if err != nil {
+		return nil, err
+	}
+	return models, err
+}
+
+// Retrieves name of organism given a specific organism ID
+func GetOrganismName(organismID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var name string
+	query := "SELECT name FROM organism WHERE ID = ?"
+	err = db.Get(&name, query, organismID)
+	if err != nil {
+		return "", err
+	}
+	return name
+}
+
+// Retrieves ID of organism given a specific organism name
+func GetOrganismID(organismName string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var ID string
+	query := "SELECT ID FROM organism WHERE name = ?"
+	err = db.Get(&ID, query, organismName)
+	if err != nil {
+		return "", err
+	}
+	return ID
+}
+
+// Retrieves compound ID given a compound name
+func GetCompoundID(compoundName string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var ID string
+	query := "SELECT ID FROM compound WHERE name = ?"
+	err = db.Get(&ID, query, compoundName)
+	if err != nil {
+		return "", err
+	}
+	return ID
+}
+
+// Retrieves compound ID with the most similar name to the given compound name
+func GetLikeCompoundID(compoundName string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var ID string
+	query := "SELECT ID FROM compound WHERE name LIKE ?"
+	err = db.Get(&ID, query, compoundName)
+	if err != nil {
+		return "", err
+	}
+	return ID
+}
+
+// Retrieves compound ID given an inchi string
+func GetCompoundIDFromInchi(inchi string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var ID string
+	query := "SELECT ID FROM compound WHERE inchistring = ?"
+	err = db.Get(&ID, query, inchi)
+	if err != nil {
+		return "", err
+	}
+	return ID
+}
+
+//Retrieves inchi string given a compound ID
+func GetCompoundInchi(compoundID string) (string, error) {	
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var inchi string
+	query := "SELECT inchistring FROM compound WHERE ID = ?"
+	err = db.Get(&inchi, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return inchi
+}
+
+
+// Retrieves compound name given a compound ID
+func GetCompoundName(compoundID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var name string
+	query := "SELECT name FROM compound WHERE ID = ?"
+	err = db.Get(&name, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return name
+}
+
+// Retrieves compound name given an inchi string
+func GetCompoundNameFromInchi(inchi string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var name string
+	query := "SELECT name FROM compound WHERE inchistring = ?"
+	err = db.Get(&name, query, inchi)
+	if err != nil {
+		return "", err
+	}
+	return name
+}
+
+// Retrieves the compartment that the compound is in
+func GetCompoundCompartment(compoundID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var compartment string
+	query := "SELECT compartment FROM compound WHERE ID = ?"
+	err = db.Get(&compartment, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return compartment
+}
+
+// Retrieves name of the reaction given the reaction ID
+func GetReactionName(reactionID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var name string
+	query := "SELECT name FROM reaction WHERE ID = ?"
+	err = db.Get(&name, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return name
+}
+
+// Retrieves reaction IDs that have a given compound ID as a reactant or product
+func GetReactionIDsFromCompound(compoundID string, isProduct bool) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var reactionIDs []string
+	query := "SELECT reaction_ID FROM reaction_compound WHERE cpd_ID = ? AND is_product = ?"
+	err = db.Select(&reactionIDs, query, compoundID, isProduct)
+	if err != nil {
+		return nil, err
+	}
+	return reactionIDs, err
+}
+
+// Retrieves Model IDs that are in a given a reaction
+func GetReactionSpecies(reactionID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var species []string
+	query := "SELECT model_ID FROM model_reaction INDEXED BY modelreaction_ind2 WHERE reaction_ID = ?"
+	err = db.Select(&species, query, reactionID)
+	if err != nil {
+		return nil, err
+	}
+	return species, err
+}
+
+// Retrieves reactions (Reaction IDs) that have a given compound (ID) as a reactant
+func GetReactantCompoundIDs(reactionID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var compoundIDs []string
+	query := "SELECT cpd_ID FROM reaction_compound WHERE reaction_ID = ? AND is_product = ?"
+	err = db.Select(&compoundIDs, query, reactionID, false)
+	if err != nil {
+		return nil, err
+	}
+	return compoundIDs, err
+}
+
+// Retrieves reactions (reaction IDs) that have a given compound (ID) as a product
+func GetReactionsWithProduct(compoundID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var compoundIDs []string
+	query := "SELECT reaction_ID FROM reaction_compound WHERE cpd_ID = ? AND is_prod = ?"
+	err = db.Select(&compoundIDs, query, reactionID, true)
+	if err != nil {
+		return nil, err
+	}
+	return compoundIDs, err
+}
+
+// Retrieves products (compound IDs) of a given reaction (ID)
+func GetProductCompundIDs(reactionID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var products []string
+	query := "SELECT cpd_ID FROM reaction_compound WHERE reaction_ID = ? AND is_prod = ?"
+	err = db.Select(&products, query, reactionID, true)
+	if err != nil {
+		return nil, err
+	}
+	return products, err
+}
+
+// Retrives all compounds in a metabolic model given model ID
+func GetModelCompounds(modelID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var compounds []string
+	query := "SELECT cpd_ID FROM model_compound WHERE model_ID = ?"
+	err = db.Select(&compounds, query, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return compounds, err
+}
+
+// Retrieves all comounds in the database
+func GetAllCompounds() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var compounds []string
+	query := "SELECT ID FROM compound"
+	err = db.Select(&compounds, query)
+	if err != nil {
+		return nil, err
+	}
+	return compounds, err
+}
+
+// Retrieves all compound inchistrings in the database
+func GetAllCompoundInchistrings() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var inchistrings []string
+	query := "SELECT inchistring FROM compound"
+	err = db.Select(&inchistrings, query)
+	if err != nil {
+		return nil, err
+	}
+	return inchistrings, err
+}
+
+// Retrieves all reactions in a metabolic model given model ID
+func GetModelReactions(modelID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var reactions []string
+	query := "SELECT reaction_ID FROM model_reaction WHERE model_ID = ?"
+	err = db.Select(&reactions, query, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return reactions, err
+}
+
+// Retrieves all reactions in the database
+func GetAllReactions() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var reactions []string
+	query := "SELECT ID FROM reaction"
+	err = db.Select(&reactions, query)
+	if err != nil {
+		return nil, err
+	}
+	return reactions, err
+}
+
+// Retrieves reverisbility information of a reaction in a specified metabolic model (model ID)
+func GetReactionReversibility(reactionID string, modelID string) (bool, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return false, err
+	}
+	var reversible bool
+	query := "SELECT is_rev FROM model_reaction WHERE reaction_ID = ? AND model_ID = ?"
+	err = db.Get(&reversible, query, reactionID, modelID)
+	if err != nil {
+		return false, err
+	}
+	return reversible, err
+}
+
+// Retrieves reversibility information of a reaction independent of model
+func GetReactionReversibilityGlobal(reactionID string) (bool, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return false, err
+	}
+	var reversible bool
+	query := "SELECT is_reversible FROM reaction_reversibility WHERE reaction_ID = ?"
+	err = db.Get(&reversible, query, reactionID)
+	if err != nil {
+		return false, err
+	}
+	return reversible, err
+}
+
+//Retrieves gene associations for a reaction of a given metabolic network (model ID)
+func GetReactionGeneAssociations(reactionID string, modelID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var genes []string
+	query := "SELECT gene_ID FROM reaction_gene WHERE reaction_ID = ? AND model_ID = ?"
+	err = db.Select(&genes, query, reactionID, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return genes, err
+}
+
+// Retrieves protein associations for a reaction of a given metabolic network (model ID)
+func GetReactionProteinAssociations(reactionID string, modelID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var proteins []string
+	query := "SELECT protein_ID FROM reaction_protein WHERE reaction_ID = ? AND model_ID = ?"
+	err = db.Select(&proteins, query, reactionID, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return proteins, err
+}
+
+// Retrieves stoichiometry of a compound for a given reaction
+func GetStoichiometry(reactionID string, compoundID string, isProduct bool) (float64, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return 0, err
+	}
+	var stoichiometry float64
+	query := "SELECT stoichiometry FROM reaction_compound WHERE reaction_ID = ? AND cpd_ID = ? AND is_prod = ?"
+	err = db.Get(&stoichiometry, query, reactionID, compoundID, isProduct)
+	if err != nil {
+		return 0, err
+	}
+	return stoichiometry, err
+}
+
+// Retrieves the catalyst of reaction
+func GetReactionCatalyst(reactionID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var catalyst string
+	query := "SELECT catalysts_ID FROM reaction_catalysts WHERE reaction_ID = ?"
+	err = db.Get(&catalyst, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return catalyst, err
+}
+
+// Retrieves the compartment ID
+func GetCompartmentID(compartmentName string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var compartmentID string
+	query := "SELECT ID FROM compartments WHERE name LIKE ?"
+	err = db.Get(&compartmentID, query, compartmentName)
+	if err != nil {
+		return "", err
+	}
+	return compartmentID, err
+}
+
+// Retrieves solvents of reaction
+func GetReactionSolvents(reactionID string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var solvent []string
+	query := "SELECT solvents_ID FROM reaction_solvents WHERE reaction_ID = ?"
+	err = db.Get(&solvent, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return solvent, err
+}
+
+// Retrieves the temperaature of the reaction is performed at
+func GetReactionTemperature(reactionID string) (float64, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var temperature float64
+	query := "SELECT temperature FROM reaction_spresi_info WHERE reaction_ID = ?"
+	err = db.Get(&temperature, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return temperature, err
+}
+
+// Retrieves the pressure reaction is performed at
+func GetReactionPressure(reactionID string) (float64, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var pressure float64
+	query := "SELECT pressure FROM reaction_spresi_info WHERE reaction_ID = ?"
+	err = db.Get(&pressure, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return pressure, err
+}
+
+// Retrieves the time that is required to perform reaction
+func GetReactionTime(reactionID string) (float64, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var time float64
+	query := "SELECT total_time FROM reaction_spresi_info WHERE reaction_ID = ?"
+	err = db.Get(&time, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return time, err
+}
+
+// Retrieves yield that was reported with reaction
+func GetReactionYield(reactionID string) (float64, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var yield float64
+	query := "SELECT yield FROM reaction_spresi_info WHERE reaction_ID = ?"
+	err = db.Get(&yield, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return yield, err
+}
+
+// Retrieves the reference of reaction
+func GetReactionReference(reactionID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var reference string
+	query := "SELECT reference FROM reaction_spresi_info WHERE reaction_ID = ?"
+	err = db.Get(&reference, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return reference, err
+}
+
+// Retrieves reactions based on type
+func GetReactionsByType(reactionType string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var reactions []string
+	query := "SELECT ID FROM reactions WHERE type = ?"
+	err = db.Select(&reactions, query, reactionType)
+	if err != nil {
+		return nil, err
+	}
+	return reactions, err
+}
+
+// Retrieves reaction on type
+func GetReactionType(reactionID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var reactionType string
+	query := "SELECT type FROM reactions WHERE ID = ?"
+	err = db.Get(&reactionType, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return reactionType, err
+}
+
+// Retrieves all reaction KEGG IDs
+func GetAllReactionKEGGIDs() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var reactionIDs []string
+	query := "SELECT kegg_id FROM reaction"
+	err = db.Select(&reactionIDs, query)
+	if err != nil {
+		return nil, err
+	}
+	return reactionIDs, err
+}
+
+// Retrieves kegg ID for a reaction based on main ID
+func GetReactionKEGGID(reactionID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var reactionKEGGID string
+	query := "SELECT kegg_id FROM reaction WHERE ID = ?"
+	err = db.Get(&reactionKEGGID, query, reactionID)
+	if err != nil {
+		return "", err
+	}
+	return reactionKEGGID, err
+}
+
+// Retrieves kegg ID for a compound based on main ID
+func GetCompoundKEGGID(compoundID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var compoundKEGGID string
+	query := "SELECT kegg_id FROM compound WHERE ID = ?"
+	err = db.Get(&compoundKEGGID, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return compoundKEGGID, err
+}
+
+// Retrieves all compound Kegg IDs
+func GetAllCompoundKEGGIDs() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var compoundIDs []string
+	query := "SELECT kegg_id FROM compound"
+	err = db.Select(&compoundIDs, query)
+	if err != nil {
+		return nil, err
+	}
+	return compoundIDs, err
+}
+
+// Retrieves all chemicalformulas
+func GetAllChemicalFormulas() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var formulas []string
+	query := "SELECT chemicalformula FROM compound"
+	err = db.Select(&formulas, query)
+	if err != nil {
+		return nil, err
+	}
+	return formulas, err
+}
+
+// Retrieves chemicalformula for compound ID
+func GetChemicalFormula(compoundID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var formula string
+	query := "SELECT chemicalformula FROM compound WHERE ID = ?"
+	err = db.Get(&formula, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return formula, err
+}
+
+// Retrieves casnumber for compound ID
+func GetCASNumber(compoundID string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var casNumber string
+	query := "SELECT casnumber FROM compound WHERE ID = ?"
+	err = db.Get(&casNumber, query, compoundID)
+	if err != nil {
+		return "", err
+	}
+	return casNumber, err
+}
+
+// Retrieves compound IDs for Chemical formula
+func GetCompoundIDByFormula(formula string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var compoundIDs []string
+	query := "SELECT ID FROM compound WHERE chemicalformula = ?"
+	err = db.Get(&compoundIDs, query, formula)
+	if err != nil {
+		return "", err
+	}
+	return compoundIDs, err
+}
+
+// Retrieves compound name for given search term (name/formula) TODO: Add more match criteria
+func GetCompoundNameBySearchTerm(searchTerm string) ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var compoundNames []string
+	query := "SELECT name FROM compound WHERE name LIKE ? OR chemicalformula LIKE ? OR ID LIKE ? OR kegg_id LIKE ? OR casnumber LIKE ?"
+	err = db.Get(&compoundNames, query, searchTerm, searchTerm, searchTerm, searchTerm, searchTerm)
+	if err != nil {
+		return "", err
+	}
+	return compoundNames, err
+}
+
+// Retrieves model ID for given file_name
+func GetModelIDByFileName(fileName string) (string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return "", err
+	}
+	var modelID string
+	query := "SELECT ID FROM model WHERE file_name = ?"
+	err = db.Get(&modelID, query, fileName)
+	if err != nil {
+		return "", err
+	}
+	return modelID, err
+}
+
+// Retrieves all model IDs in the database
+func GetAllModelIDs() ([]string, error) {
+	db, err := ConnectDB()
+	if err != nil {
+		return nil, err
+	}
+	var modelIDs []string
+	query := "SELECT ID FROM fba_models"
+	err = db.Select(&modelIDs, query)
+	if err != nil {
+		return nil, err
+	}
+	return modelIDs, err
+}
+

--- a/pkg/retsynth/queries_test.go
+++ b/pkg/retsynth/queries_test.go
@@ -1,0 +1,405 @@
+/*
+Package retsynth_test contains tests for the queries.go in the retsynth package.
+*/
+package retsynth_test
+
+import (
+	"testing"
+
+	"github.com/TimothyStiles/allbase/pkg/retsynth"
+)
+
+func TestConnectDB(t *testing.T) {
+	_, err := retsynth.ConnectDB()
+	if err != nil {
+		t.Error("Error connecting to the database")
+	}
+}
+
+func TestGetUniqueMetabolicClusters(t *testing.T) {
+	_, err := retsynth.GetUniqueMetabolicClusters()
+	if err != nil {
+		t.Error("Error getting unique metabolic clusters")
+	}
+}
+
+func TestGetAllModelIDs(t *testing.T) {
+	_, err := retsynth.GetAllModelIDs()
+	if err != nil {
+		t.Error("Error getting all model ids")
+	}
+}
+
+func TestGetOrganismName(t *testing.T) {
+	var name string = "Escherichia coli"
+	_, err := retsynth.GetOrganismName(name)
+	if err != nil {
+		t.Error("Error getting organism names")
+	}
+}
+
+func TestGetOrganismID(t *testing.T) {
+	var organismID string = "83333"
+	_, err := retsynth.GetOrganismID(organismID)
+	if err != nil {
+		t.Error("Error getting organism ids")
+	}
+}
+
+func TestGetCompoundID(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCompoundID(compoundID)
+	if err != nil {
+		t.Error("Error getting compound ids")
+	}
+}
+
+func TestGetLikeCompoundID(t *testing.T) {
+	var compundName string = "glucose"
+	_, err := retsynth.GetLikeCompoundID(compundName)
+	if err != nil {
+		t.Error("Error getting like compound ids")
+	}
+}
+
+func TestGetCompoundIDFromInchi(t *testing.T) {
+	var inchistring string = "InChI=1S/C3H4O3S/c4-2(1-7)3(5)6/h7H,1H2,(H,5,6)_c0"
+	_, err := retsynth.GetCompoundIDFromInchi(inchistring)
+	if err != nil {
+		t.Error("Error getting compound ids from inchi")
+	}
+}
+
+func TestGetCompoundInchi(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCompoundInchi(compoundID)
+	if err != nil {
+		t.Error("Error getting compound inchi")
+	}
+}
+
+func TestGetCompoundName(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCompoundName(compoundID)
+	if err != nil {
+		t.Error("Error getting compound names")
+	}
+}
+
+func TestGetCompoundNameFromInchi(t *testing.T) {
+	var inchistring string = "InChI=1S/C5H11O8P/c6-1-3(7)5(9)4(8)2-13-14(10,11)12/h1,3-5,7-9H,2H2,(H2,10,11,12)/t3-,4-,5+/m1/s1_c0"
+	_, err := retsynth.GetCompoundNameFromInchi(inchistring)
+	if err != nil {
+		t.Error("Error getting compound names from inchi")
+	}
+}
+
+func TestGetCompoundCompartment(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCompoundCompartment(compoundID)
+	if err != nil {
+		t.Error("Error getting compound compartments")
+	}
+}
+
+func TestGetReactionName(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionName(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction names")
+	}
+}
+
+func TestGetReactionIDsFromCompound(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetReactionIDsFromCompound(compoundID, true)
+	if err != nil {
+		t.Error("Error getting reaction ids from compound")
+	}
+
+	// Test for false | Figure out the exact assertions and the test case
+	_, err = retsynth.GetReactionIDsFromCompound(compoundID, false)
+	if err != nil {
+		t.Error("Error getting reaction ids from compound")
+	}
+
+}
+
+func TestGetReactionSpecies(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionSpecies(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction species")
+	}
+}
+
+func TestGetReactantCompoundIDs(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactantCompoundIDs(reactionID)
+	if err != nil {
+		t.Error("Error getting reactant compound ids")
+	}
+}
+
+func TestGetReactionsWithProduct(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetReactionsWithProduct(compoundID)
+	if err != nil {
+		t.Error("Error getting reactions with product")
+	}
+}
+
+func TestGetProductCompundIDs(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetProductCompundIDs(reactionID)
+	if err != nil {
+		t.Error("Error getting product compound ids")
+	}
+}
+
+func TestGetModelCompounds(t *testing.T) {
+	var modelID string = "iJO1366"
+	_, err := retsynth.GetModelCompounds(modelID)
+	if err != nil {
+		t.Error("Error getting model compounds")
+	}
+}
+
+func TestGetAllCompounds(t *testing.T) {
+	_, err := retsynth.GetAllCompounds()
+	if err != nil {
+		t.Error("Error getting all compounds")
+	}
+}
+
+func TestGetAllCompoundInchistrings(t *testing.T) {
+	_, err := retsynth.GetAllCompoundInchistrings()
+	if err != nil {
+		t.Error("Error getting all compound inchistrings")
+	}
+}
+
+func TestGetModelReactions(t *testing.T) {
+	var modelID string = "iJO1366"
+	_, err := retsynth.GetModelReactions(modelID)
+	if err != nil {
+		t.Error("Error getting model reactions")
+	}
+}
+
+func TestGetAllReactions(t *testing.T) {
+	_, err := retsynth.GetAllReactions()
+	if err != nil {
+		t.Error("Error getting all reactions")
+	}
+}
+
+func TestGetReactionReversibility(t *testing.T) {
+	var reactionID string = "rxn00001"
+	var modelID string = "iJO1366"
+	_, err := retsynth.GetReactionReversibility(reactionID, modelID)
+	if err != nil {
+		t.Error("Error getting reaction reversibility")
+	}
+}
+
+func TestGetReactionReversibilityGlobal(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionReversibilityGlobal(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction reversibility global")
+	}
+}
+
+func TestGetReactionGeneAssociations(t *testing.T) {
+	var reactionID string = "rxn00001"
+	var modelID string = "iJO1366"
+	_, err := retsynth.GetReactionGeneAssociations(reactionID, modelID)
+	if err != nil {
+		t.Error("Error getting reaction gene associations")
+	}
+}
+
+func TestGetReactionProteinAssociations(t *testing.T) {
+	var reactionID string = "rxn00001"
+	var modelID string = "iJO1366"
+	_, err := retsynth.GetReactionProteinAssociations(reactionID, modelID)
+	if err != nil {
+		t.Error("Error getting reaction protein associations")
+	}
+}
+
+func TestGetStoichiometry(t *testing.T) {
+	var reactionID string = "rxn00001"
+	var compoundID string = "cpd00001"
+	var isProduct bool = true
+	_, err := retsynth.GetStoichiometry(reactionID, compoundID, isProduct)
+	if err != nil {
+		t.Error("Error getting stoichiometry")
+	}
+}
+
+func TestGetReactionCatalyst(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionCatalysts(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction catalysts")
+	}
+}
+
+func TestGetCompartmentID(t *testing.T) {
+	var compartmentID string = "c"
+	_, err := retsynth.GetCompartmentID(compartmentID)
+	if err != nil {
+		t.Error("Error getting compartment ids")
+	}
+}
+
+func TestGetReactionSolvents(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionSolvents(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction solvents")
+	}
+}
+
+func TestGetReactionTemperature(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionTemperature(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction temperature")
+	}
+}
+
+func TestGetReactionPressure(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionPressure(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction pressure")
+	}
+}
+
+func TestGetReactionTime(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionTime(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction time")
+	}
+}
+
+func TestGetReactionYield(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionYield(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction yield")
+	}
+}
+
+func TestGetReactionReference(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionReference(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction references")
+	}
+}
+
+func TestGetReactionsByType(t *testing.T) {
+	var reactionType string = "bio"
+	_, err := retsynth.GetReactionsByType(reactionType)
+	if err != nil {
+		t.Error("Error getting reactions by type")
+	}
+}
+
+func TestGetReactionType(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionType(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction type")
+	}
+}
+
+func TestGetAllReactionKEGGIDs(t *testing.T) {
+	_, err := retsynth.GetAllReactionKEGGIDs()
+	if err != nil {
+		t.Error("Error getting all reaction kegg ids")
+	}
+}
+
+func TestGetReactionKEGGID(t *testing.T) {
+	var reactionID string = "rxn00001"
+	_, err := retsynth.GetReactionKEGGID(reactionID)
+	if err != nil {
+		t.Error("Error getting reaction kegg id")
+	}
+}
+
+func TestGetCompoundKEGGID(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCompoundKEGGID(compoundID)
+	if err != nil {
+		t.Error("Error getting compound kegg id")
+	}
+}
+
+func GetAllCompoundKEGGIDs(t *testing.T) {
+	_, err := retsynth.GetAllCompoundKEGGIDs()
+	if err != nil {
+		t.Error("Error getting all compound kegg ids")
+	}
+}
+
+func GetAllChemicalFormulas(t *testing.T) {
+	_, err := retsynth.GetAllChemicalFormulas()
+	if err != nil {
+		t.Error("Error getting all chemical formulas")
+	}
+}
+
+func TestGetChemicalFormula(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetChemicalFormula(compoundID)
+	if err != nil {
+		t.Error("Error getting chemical formula")
+	}
+}
+
+func TestGetCASNumber(t *testing.T) {
+	var compoundID string = "cpd00001"
+	_, err := retsynth.GetCASNumber(compoundID)
+	if err != nil {
+		t.Error("Error getting cas number")
+	}
+}
+
+func TestGetCompoundIDByFormula(t *testing.T) {
+	var formula string = "C6H12O6"
+	_, err := retsynth.GetCompoundIDByFormula(formula)
+	if err != nil {
+		t.Error("Error getting compound id by formula")
+	}
+}
+
+func TestGetCompoundNameBySearchTerm(t *testing.T) {
+	var searchTerm string = "glucose"
+	_, err := retsynth.GetCompoundNameBySearchTerm(searchTerm)
+	if err != nil {
+		t.Error("Error getting compound name by search term")
+	}
+}
+
+func TestGetModelIDByFileName(t *testing.T) {
+	var fileName string = "iJO1366.xml"
+	_, err := retsynth.GetModelIDByFileName(fileName)
+	if err != nil {
+		t.Error("Error getting model id by file name")
+	}
+}
+
+func TestGetAllFBAModelIDs(t *testing.T) {
+	_, err := retsynth.GetAllFBAModelIDs()
+	if err != nil {
+		t.Error("Error getting all fba model ids")
+	}
+}
+


### PR DESCRIPTION
This is a draft pull request for an API integration that adds support for retsynth data dumps. This PR reflects the baseline support for incorporating `allbase` within Upp Bio

TODO: 
- [ ] Merge the data models utilized by retsynth with the `allbase` data models 
- [ ] Move away from SQLite to SurrealDB
- [ ] Develop Standardized GraphQL architecture for cable API development
- [ ] Add edit history tracking for the database
